### PR TITLE
[FIX] Android Oauth2 관련 수정 및 Deeplink 적용

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,14 @@
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="greendev"
+                    android:host="open.app" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".view.activity.MainActivity"

--- a/app/src/main/java/com/example/greendev/view/activity/LoginActivity.kt
+++ b/app/src/main/java/com/example/greendev/view/activity/LoginActivity.kt
@@ -69,7 +69,7 @@ class LoginActivity : BindingActivity<ActivityLoginBinding>(R.layout.activity_lo
             }
         }
 
-        val initialUrl = "https://greendev-api.dev-lr.com/oauth2/authorization/$service?redirect_uri=https://greendev.dev-lr.com"
+        val initialUrl = "https://greendev-api.dev-lr.com/oauth2/authorization/$service?redirect_uri=greendev://open.app"
         webView.loadUrl(initialUrl)
 
         webView.setOnKeyListener { _, keyCode, event ->


### PR DESCRIPTION
## Summary
Android 애플리케이션에 Deeplink를 적용하였습니다.

## Description
- Manifest에 `Intent-Filter`를 추가하여, `greendev://open.app`의 Deeplink를 적용하였습니다. 해당 Deeplink에 접근 시, `LoginActivity`로 진입이 이루어집니다.
- `LoginActivity` 내에서 BE측에 Oauth2 요청 시, `redirection_url`을 기존의 FE측 URL이 아닌, 새로 정의한 애플리케이션측의 Deeplink를 전달하도록 변경하였습니다.
- GitHub 연동 로그인을 통해 테스트가 완료되었으며, Google, Naver 및 Kakao 연동 로그인의 경우 추후 로그인불가 Issue가 해결된 이후의 테스트가 필요합니다. 다만, 별다른 특별한 로직이 없어 문제는 없을 것으로 예상됩니다.